### PR TITLE
use pedersen instead of keccak256 for packed hash

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -3874,7 +3874,7 @@ string YulUtilFunctions::packedHashFunction(
 			function <functionName>(<variables>) -> hash {
 				let pos := <allocateUnbounded>()
 				let end := <packedEncode>(pos <comma> <variables>)
-				hash := keccak256(pos, sub(end, pos))
+				hash := pedersen(pos, sub(end, pos))
 			}
 		)");
 		templ("functionName", functionName);


### PR DESCRIPTION
It is used to make a hash-trail for mapping arguments and event
     arguments. It is fine (and much more efficient in Cairo) to use
     pedersen for such purposes